### PR TITLE
高解像度の画面で staff のアイコンのサイズが視認できるように修正

### DIFF
--- a/_sass/global/page.scss
+++ b/_sass/global/page.scss
@@ -437,6 +437,14 @@ table thead th {
       width: 100%;
       height: 25px;
     }
+
+    @media screen and (min-width: 1000px) {
+      width: 20%;
+
+      .member-image {
+        max-height: unset;
+      }
+    }
   }
   .member:hover p {
     font-weight: bold;


### PR DESCRIPTION
4K などの高解像度の画面でも、 staff のアイコンが視認できるように修正しました。