### PR TITLE
Fix warnings raised by HTMLProofer

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -1,5 +1,5 @@
 - name: 若林健一
-  site: http://crssrds.jp/aboutme/
+  site: https://crssrds.jp/aboutme/
   img: kwaka1208.png
 - name: Katz Ueno
   site: https://katzueno.com

--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -29,7 +29,7 @@
   speaker: 阿部 和広
   affiliation: 青山学院大学大学院社会情報学研究科特任教授
   news-link: /posts/owakon/
-  links: http://www.amazon.co.jp/-/e/B00DUV6S3E/
+  links: https://www.amazon.co.jp/-/e/B00DUV6S3E/
   profile-img: abe-kazuhiro.jpg
   profile-text: 1987年より一貫してオブジェクト指向言語Smalltalkの研究開発に従事。パソコンの父として知られSmalltalkの開発者であるアラン・ケイ博士の指導を2001年から受ける。Squeak EtoysとScratchの日本語版を担当。子供と教員向け講習会を多数開催。OLPC($100 laptop)計画にも参加。 
   slides: 

--- a/_posts/2023-07-18-owakon.md
+++ b/_posts/2023-07-18-owakon.md
@@ -31,4 +31,4 @@ Scratch Day 2023 in TokyoでSNS上をざわつかせた「プログラミング�
 2003年度IPA認定スーパークリエータ。元文部科学省プログラミング学習に関する調査研究委員。
 
 ## 関連リンク
-- [Amazon著者ページ](http://www.amazon.co.jp/-/e/B00DUV6S3E/){:target="_blank"}
+- [Amazon著者ページ](https://www.amazon.co.jp/-/e/B00DUV6S3E/){:target="_blank"}

--- a/index.md
+++ b/index.md
@@ -7,23 +7,23 @@ layout: default
   </div>
   <div class='information'>
     <div class="theme">Be Cool</div>
-    <img src="/img/2023/logo_640x160.svg">
+    <img src="/img/2023/logo_640x160.svg" alt='Cover Photo'>
     <div class="event-date-and-location">
       <p>2023.8.27 Sun<br>at 奈良女子大学 Nara Women's University</p>
     </div>
   </div>
   <div class="character">
-    <img src="/img/2023/mv-fumanara.png">
+    <img src="/img/2023/mv-fumanara.png" alt='Icon Character FUMA Nara'>
   </div>
 </div>
 
 
-<img src="/img/2023/deco.svg">
+<img src="/img/2023/deco.svg" alt='Transition from Cover to Contents'>
 <div id='colored_zone'>
   <h2 class="title-welcome">WELCOME TO</h2>
   <div></div>
   <div class='dojocon-image'>
-    <img src="/img/2023/52554972726_b2da260763_o.jpg">
+    <img src="/img/2023/52554972726_b2da260763_o.jpg" alt='DojoCon Japan 2022 の様子（写真）'>
   </div>
   <div class="about-dojocon">
     <div class='short'>
@@ -47,7 +47,7 @@ layout: default
     </div>
   </div>
   <div class='coderdojo-logo'>
-    <img src="/img/2023/coderdojo_logo.jpg">
+    <img src="/img/2023/coderdojo_logo.jpg" alt='CoderDojo の公式ロゴ画像'>
   </div>
   <div class='spacing2'></div>
   <div class='about-dojocon-this-year'>
@@ -76,7 +76,7 @@ layout: default
         <p class="about-title">場所</p>
         <p class="about-text">{{ site.venue }} （<a href='{{ site.map }}' target='blank'>Google Maps</a> )</p>
         <div class='map'>
-          <img src='/img/{{ site.year }}/top/map.png'>
+          <img src='/img/{{ site.year }}/top/map.png' alt='最寄駅から会場へのアクセス方法'>
         </div>
       </div>
       <div class="col-md-8 offset-md-2">
@@ -98,7 +98,7 @@ layout: default
 
   <div class="container-fruid">
     <section id="news" class="section-gray">
-      <img src="/img/2023/deco.svg">
+      <img src="/img/2023/deco.svg" alt='Transition from Contents to News'>
       <div class="section-contents">
         <h2 class="text-center title-text">NEWS</h2>
         <p class="caption text-center">お知らせ</p>


### PR DESCRIPTION
@kwaka1208 @takusandayooo HTMLProofer を実行して出てきた警告を一通り直しました!

- e0e69fd: 目が不自由な方向けに、各画像に alt 属性の情報を付与
  - cf. [総務省 - ウェブアクセシビリティ - 画像の代替テキストを提供する](https://www.soumu.go.jp/soutsu/tokai/siensaku/accessibility/L2_alt.html)
- f8eb627: Google Page ランク向上のため、SSL 対応済みの場合は HTTPS に変更
  - cf. [Google - ランキング シグナルとしての HTTPS](    https://developers.google.com/search/blog/2014/08/https-as-ranking-signal)

📝 補足: [HTMLProofer](https://github.com/gjtorikian/html-proofer#readme) は静的サイトジェネレーター (Jekyll など) 用のチェックツールです 🤖 ✅ 
https://github.com/gjtorikian/html-proofer#readme

## Before
```console
$ bundle exec rake test

...

Checking 63 internal links
Checking internal link hashes in 2 files
Ran on 22 files!

For the Images check, the following failures were found:

* At _site/index.html:125:
  image /img/2023/logo_640x160.svg does not have an alt attribute

* At _site/index.html:131:
  image /img/2023/mv-fumanara.png does not have an alt attribute

* At _site/index.html:135:
  image /img/2023/deco.svg does not have an alt attribute

* At _site/index.html:140:
  image /img/2023/52554972726_b2da260763_o.jpg does not have an alt attribute

* At _site/index.html:164:
  image /img/2023/coderdojo_logo.jpg does not have an alt attribute

* At _site/index.html:193:
  image /img/2023/top/map.png does not have an alt attribute

* At _site/index.html:215:
  image /img/2023/deco.svg does not have an alt attribute

For the Links check, the following failures were found:

* At _site/index.html:483:
  http://crssrds.jp/aboutme/ is not an HTTPS link

* At _site/posts/owakon/index.html:161:
  http://www.amazon.co.jp/-/e/B00DUV6S3E/ is not an HTTPS link

* At _site/sessions.html:219:
  http://www.amazon.co.jp/-/e/B00DUV6S3E/ is not an HTTPS link
```

## After
```console
$ bundle exec rake test

...

Checking 63 internal links
Checking internal link hashes in 2 files
Ran on 22 files!


HTML-Proofer finished successfully.
```