### PR TITLE
お知らせの表示方法を修正

### DIFF
--- a/_pages/news.md
+++ b/_pages/news.md
@@ -1,0 +1,21 @@
+---
+layout: default
+permalink: /news
+---
+
+<div class="container-fruid">
+  <section class="section-gray">
+    <div class="section-contents">
+      <h2 class="text-center title-text">NEWS</h2>
+      <p class="caption text-center">お知らせ</p>
+      <div class="row mx-2 mx-md-0">
+        {% for post in site.posts %}
+        {% include articles.html %}
+        {% endfor %}
+      </div>
+    </div>
+    <div class="mt-4">
+      {% include back-to-top.html %}
+    </div>
+  </section>
+</div>

--- a/index.md
+++ b/index.md
@@ -102,12 +102,18 @@ layout: default
       <div class="section-contents">
         <h2 class="text-center title-text">NEWS</h2>
         <p class="caption text-center">お知らせ</p>
-        <div class=" x-scroll row">
-          {% for post in site.posts %}
+        <div class="row mx-2 mx-md-0">
+          {% for post in site.posts limit:3 %}
             {% include articles.html %}
           {% endfor %}
         </div>
       </div>
+      <a href="/news"
+        class="nav-item nav-link active link_button mt-4"
+        style="padding-left:30px;padding-right: 30px;color:white;font-weight: normal;"
+        >
+        もっと見る
+      </a>
     </section>
   </div>
 


### PR DESCRIPTION
お知らせの表示方法を以下のように修正しました。

- お知らせの一覧を横スクロールを解除
- お知らせ一覧ページを追加 (`/news`)
- トップページのお知らせの表示数を最新 3 つに変更
- トップページのお知らせにもっと見るボタンを追加