### PR TITLE
Strip HTML tags like `<br>` from OGP settings

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
   {% include googleanalytics.html %}
   {% endif %}
   {% if page.title %}
-  <title>{{ page.title }} | {{ site.title }} {{ site.year }}</title>
+  <title>{{ page.title | strip_html }} | {{ site.title }} {{ site.year }}</title>
   {% else %}
   <title>{{ site.title }} {{ site.year }} | {{ site.subtitle }}</title>
   {% endif %}
@@ -20,7 +20,7 @@
   <meta name="twitter:site"  content="@DojoConJapan" />
   <meta property="og:url"    content="{{ site.url }}{{ page.url }}" />
   {% if page.title %}
-  <meta property="og:title"  content="{{ page.title }} | {{ site.title }} {{ site.year }}" />
+  <meta property="og:title"  content="{{ page.title | strip_html }} | {{ site.title }} {{ site.year }}" />
   {% else %}
   <meta property="og:title"  content="{{ site.title }} {{ site.year }} | {{ site.subtitle }}" />
   {% endif %}
@@ -39,9 +39,9 @@
   <meta property="og:type" content="website" />
   {% endif %}
 
-  <meta property="og:description"  content="{{ site.description }}" />
-  <meta name="description"         content="{{ site.description }}" />
-  <meta name="twitter:description" content="{{ site.description }}" />
+  <meta property="og:description"  content="{{ site.description | strip_html }}" />
+  <meta name="description"         content="{{ site.description | strip_html }}" />
+  <meta name="twitter:description" content="{{ site.description | strip_html }}" />
 
   <meta property="fb:app_id" content="1750803431730303" />
 


### PR DESCRIPTION
@kwaka1208 @takusandayooo OGP の中に `<br>` などが入っていた場合は、`strip_html` フィルターを使って HTML タグを取り除くようにしました! ✂️ ✨ 


## Before <---> After
<img width="1678" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/4ecb2693-6b89-4c73-972d-64ed314ddb02">

## 備考（後でやるます）

また作業の途中で OGP の `content="..."` が壊れてるっぽいようなので、後で詳しく調査して、解決できそうなら後で別途 PR にしておきます! (たぶん escape のし忘れっぽいので、escape すればすぐ直りそう...? 🤔💭)

<img width="559" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/c15c2aa0-63ba-49bf-a5d1-3c169623ce9b">
