### PR TITLE
Add 'escape' filter to fix broken OGP tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ year: 2023
 title: DojoCon Japan
 subtitle: 'Be Cool'
 description: >-
-  "DojoCon Japan"は CoderDojo コミュニティのカンファレンスイベントです。CoderDojo 関係者を対象に運営ノウハウの共有や関係者同士の交流などを目的として毎年開催されています。
+  "DojoCon Japan" は CoderDojo コミュニティのカンファレンスイベントです。CoderDojo 関係者を対象に運営ノウハウの共有や関係者同士の交流などを目的として毎年開催されています。
 url: https://dojocon2023.coderdojo.jp
 date_published: 2023年6月11日
 date_event: 2023年8月27日（日曜）

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,9 +39,9 @@
   <meta property="og:type" content="website" />
   {% endif %}
 
-  <meta property="og:description"  content="{{ site.description | strip_html }}" />
-  <meta name="description"         content="{{ site.description | strip_html }}" />
-  <meta name="twitter:description" content="{{ site.description | strip_html }}" />
+  <meta property="og:description"  content="{{ site.description | strip_html | escape }}" />
+  <meta name="description"         content="{{ site.description | strip_html | escape }}" />
+  <meta name="twitter:description" content="{{ site.description | strip_html | escape }}" />
 
   <meta property="fb:app_id" content="1750803431730303" />
 


### PR DESCRIPTION
@kwaka1208  https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/pull/133 で書いた以下の部分を修正する PR です! 🛠💨✨

> ## 備考（後でやるます）
> 
> また作業の途中で OGP の `content="..."` が壊れてるっぽいようなので、後で詳しく調査して、解決できそうなら後で別途 PR にしておきます! (たぶん escape のし忘れっぽいので、escape すればすぐ直りそう...? 🤔💭)
> 
> <img width="559" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/c15c2aa0-63ba-49bf-a5d1-3c169623ce9b">

## Before <---> After
<img width="1129" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/c5aec470-5503-45f8-b9c3-120d38128ac9">
