### PR TITLE
Session と同様に、詳細ページがある場合は Event 画像にもリンクを付与する

### DIFF
--- a/_pages/events.md
+++ b/_pages/events.md
@@ -23,8 +23,8 @@ permalink: /events
           {% endif %}
         </p>
 
-	{% if event.url %}<a href='{{ event.url }}'>{% endif %}
-        <img class="w-100"    alt="{{ event.title }}" style='padding-bottom: 20px;'
+	{% if event.url %}<a href="{{ event.url }}">{% endif %}
+        <img class="w-100"    alt="{{ event.title }}" style="padding-bottom: 20px;"
 	  {% if event.img %}  src="{{ event.img }}"
 	  {% else %}          src="/img/{{ site.year }}/dummy.jpg"
 	  {% endif %}

--- a/_pages/events.md
+++ b/_pages/events.md
@@ -22,14 +22,17 @@ permalink: /events
           <span class="badge badge-ws">{{ event.tag }}</span>
           {% endif %}
         </p>
-        {% if event.img %}
-          <img src="{{ event.img }}" class="w-100" alt="{{ event.title }}">
-        {% else %}
-          <img src="/img/{{ site.year }}/dummy.jpg" class="w-100" alt="{{ event.title }}">
-        {% endif %}
+
+	{% if event.url %}<a href='{{ event.url }}'>{% endif %}
+        <img class="w-100"    alt="{{ event.title }}" style='padding-bottom: 20px;'
+	  {% if event.img %}  src="{{ event.img }}"
+	  {% else %}          src="/img/{{ site.year }}/dummy.jpg"
+	  {% endif %}
+	>
+	{% if event.url %}</a>{% endif %}
         <p>{{ event.text }}</p>
         {% if event.url %}
-        <p class="text-left"><a class="btn btn-main" href="{{ event.url}}">参加・詳細</a></p>
+        <p class="text-left"><a class="btn btn-main" href="{{ event.url }} ">参加・詳細</a></p>
         {% endif %}
       </div>
       {% endfor %}


### PR DESCRIPTION
本 PR の背景と内容は以下の通りです！

- Session ページでは、画像をクリックすると詳細ページに飛べる
- Event ページでは、画像をクリックしても詳細ページには飛べない
- Event ページの場合も、その詳細ページがもしあれば、詳細ページに飛べる (← 本 PR の内容)