### PR TITLE
individual sponsor のテキストの位置を修正

### DIFF
--- a/_sass/pages/index.scss
+++ b/_sass/pages/index.scss
@@ -555,6 +555,7 @@ $corner-radius: 30px;
         display: flex;
         flex-wrap: wrap;
         justify-content: space-evenly;
+        align-items: center;
 
         div.individual-sponsor-name {
           margin: 1em 2em;


### PR DESCRIPTION
individual sponsor の名前のテキストをアルファベットと日本語の場合で縦の位置が揃うように修正しました。

<img width="766" alt="individual-sponsor-fixed" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/34826373/687acb0b-55ec-462b-bc0f-a819f17e5472">
