### PR TITLE
トップページの NEWS 表示数を変更: 3つ → 6つ

### DIFF
--- a/index.md
+++ b/index.md
@@ -103,7 +103,7 @@ layout: default
         <h2 class="text-center title-text">NEWS</h2>
         <p class="caption text-center">お知らせ</p>
         <div class="row mx-2 mx-md-0">
-          {% for post in site.posts limit:3 %}
+          {% for post in site.posts limit:6 %}
             {% include articles.html %}
           {% endfor %}
         </div>


### PR DESCRIPTION
@kwaka1208 DojoCon Japan 2023 のお知らせ公開頻度が高くなり、8月1日以降のお知らせ記事（[個人スポンサーの記事](https://dojocon2023.coderdojo.jp/posts/individual-sponsors/)など）も「もっと見る」ボタンをクリックしない限り見えないようになったため、訪問者が最近のお知らせ記事に気付きやすくするために表示数を３つから６つに変更してみました。

## Before <---> After
<img width="1708" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/1e4dc69b-5ff3-486c-bc7a-a5470cb59eec">

## Why 3 to 6?

Countdown DojoCon Japan が現在２行分表示されているので、お知らせ記事についても同様に２行分（６つまで）表示するようにしています。

<img width="848" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/9dd7db30-a2f6-4aa1-8b8c-d36a19b786a6">
