### PR TITLE
デバッグ用 JSON dump を隠し機能として追加: `/exhibition.json`

### DIFF
--- a/_pages/exhibition.json
+++ b/_pages/exhibition.json
@@ -1,0 +1,18 @@
+---
+permalink: /exhibition.json
+---
+[ {% for pj in site.data.exhibition %}
+  {
+    "id"          : "{{ pj.path_URL }}",
+    "title"       : "{{ pj.title       | strip_html | escape }}",
+    "description" : "{{ pj.text        | strip_html | escape }}",
+    "tag"         : "{{ pj.tag         | strip_html | escape }}",
+    "note"        : "{{ pj.description | strip_html | escape }}",
+    "creator"     : "{{ pj.creator     | strip_html | escape }}",
+    "coderdojo_at": "{{ pj.affiliation | strip_html | escape }}",
+    "thumbnail"   : "{{ site.url }}/{{ pj.img }}",
+    "url_internal": "{{ site.url }}/{{ pj.path_URL }}",
+    "url_external": "{{ pj.URL }}"
+  }{% unless forloop.last %},{% endunless %}{% endfor %}
+]
+


### PR DESCRIPTION
一般公開されているデータ ([`_data/exhibition.yml`](https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/blob/main/_data/exhibition.yml)) を JSON 形式で出力する(主に内部向けの) デバッグ用APIを作成しました。元々HTML/YAMLとして公開されているデータをまとめただけのため、特に認証などは不要です。

これまでデバッグするときは、

1. 特定の展示ページに飛び、
2. HTMLの生成結果を確認し、
3. 不具合があればデバッグする
4. それが原因でなければ別の展示ページに飛ぶ
5. （以降、展示の数だけループする。合計で数十ステップが必要）

という工程が必要でデバッグが面倒でしたが、本PRマージ後は、

1. https://dojocon2023.coderdojo.jp/exhibition.json を見る
2. JSON 形式が invalid だったり、怪しい出力結果が無いか探す
3. もしあれば、該当データに関する処理をデバッグする

という工程になるので、最大３ステップ程度でデバッグでき、便利になる（はず）です 😌✨

📝 NOTE: カラム名は後々のことを考えて、実際のYAMLデータとは別の名前に変えています。ココは既に複数名の作業フローに組み込まれていて、今変更してしまうと混乱の元になるため、特に変更していません。（仮にリファクタリングするとしても開催後の方が混乱が少なくなってよさそう 💭）

<img width="651" alt="image" src="https://github.com/coderdojo-japan/dojocon2023.coderdojo.jp/assets/155807/682f1390-78c2-4889-a1c8-61114de51685">
